### PR TITLE
Support explicit nonterminal syntax

### DIFF
--- a/DSLKIT/DSLKIT.Test/ParserTests/ActionAndGotoTableBuilderTests.cs
+++ b/DSLKIT/DSLKIT.Test/ParserTests/ActionAndGotoTableBuilderTests.cs
@@ -192,5 +192,18 @@ namespace DSLKIT.Test.ParserTests
             grammar.ActionAndGotoTable.Should().NotBeNull();
             grammar.ActionAndGotoTable.ActionTable.Should().NotBeEmpty();
         }
+
+        [Fact]
+        public void AddProductionFromString_WithAngleBrackets_Works()
+        {
+            var grammar = new GrammarBuilder()
+                .WithGrammarName("brackets")
+                .AddProductionFromString("<S> → <A>")
+                .AddProductionFromString("<A> → a")
+                .BuildGrammar();
+
+            grammar.Productions.Should().Contain(p => p.LeftNonTerminal.Name == "S");
+            grammar.Productions.Should().Contain(p => p.LeftNonTerminal.Name == "A");
+        }
     }
 }

--- a/DSLKIT/DSLKIT.Test/ParserTests/SyntaxParserTests.cs
+++ b/DSLKIT/DSLKIT.Test/ParserTests/SyntaxParserTests.cs
@@ -73,12 +73,12 @@ namespace DSLKIT.Test.ParserTests
             // Create grammar using string notation first, then replace terminals
             var grammar = new GrammarBuilder()
                 .WithGrammarName("sjackson")
-                .AddProductionFromString("S → N")
-                .AddProductionFromString("N → V = E")
-                .AddProductionFromString("N → E")
-                .AddProductionFromString("E → V")
-                .AddProductionFromString("V → x")
-                .AddProductionFromString("V → * E")
+                .AddProductionFromString("<S> → <N>")
+                .AddProductionFromString("<N> → <V> = <E>")
+                .AddProductionFromString("<N> → <E>")
+                .AddProductionFromString("<E> → <V>")
+                .AddProductionFromString("<V> → x")
+                .AddProductionFromString("<V> → * <E>")
                 .BuildGrammar();
 
             // Now we need to use the same terminal instances for lexer

--- a/DSLKIT/DSLKIT/Terminals/GrammarBuilder.cs
+++ b/DSLKIT/DSLKIT/Terminals/GrammarBuilder.cs
@@ -184,13 +184,26 @@ namespace DSLKIT.Terminals
             }
 
             var left = production[0].Trim();
+            if (left.StartsWith("<") && left.EndsWith(">"))
+            {
+                left = left.Substring(1, left.Length - 2);
+            }
+
             var productionBuilder = AddProduction(left);
             var definition = new List<ITerm>();
+
             foreach (var item in production[1].Trim().Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
             {
                 if (item == "ε")
                 {
                     definition.Add(Empty);
+                    continue;
+                }
+
+                if (item.StartsWith("<") && item.EndsWith(">"))
+                {
+                    var ntName = item.Substring(1, item.Length - 2);
+                    definition.Add(ntName.AsNonTerminal());
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
- extend GrammarBuilder so AddProductionFromString understands `<NonTerminal>` notation
- update SyntaxParser tests to use the new format
- add a regression test for `<NonTerminal>` parsing in ActionAndGotoTableBuilderTests

## Testing
- `/usr/bin/dotnet test DSLKIT/DSLKIT.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878c4afeb60832ab19bb3cfff100997